### PR TITLE
Fix requirements.txt for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 streamlit==1.28.1
-pandas==2.1.3
-numpy==1.24.3
-scikit-learn==1.3.2
-joblib==1.3.2
-plotly==5.17.0
-xgboost==2.0.2
+pandas>=2.0.0
+numpy>=1.24.0,<2.0
+scikit-learn>=1.3.0
+joblib>=1.3.0
+plotly>=5.15.0
+xgboost>=2.0.0


### PR DESCRIPTION
- Use flexible version ranges instead of exact versions
- Fix pandas compatibility with Python 3.13
- Allow Streamlit Cloud to choose compatible versions